### PR TITLE
feat: add github action to release binary on new versions

### DIFF
--- a/.github/workflows/release-bin.yaml
+++ b/.github/workflows/release-bin.yaml
@@ -1,0 +1,31 @@
+name: Release dontgo403 binary
+
+on:
+  push:
+    tags:
+      - "*" # triggers only if push new tag version, like `0.8.4` or else
+
+jobs:
+  build:
+    name: GoReleaser build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.BuildDate={{.CommitDate}}
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
This PR adds a GitHub action that automatically builds `dontgo403` at each new tag version pushed.
The binaries will be available at https://github.com/devploit/dontgo403/releases


You can see how the action behaves on my fork of the project: https://github.com/eze-kiel/dontgo403/runs/5423836405, and the release here: https://github.com/eze-kiel/dontgo403/releases