### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module dontgo403
+module github.com/devploit/dontgo403
 
-go 1.16
+go 1.17
 
 require (
 	github.com/TwinProduction/go-color v1.0.0 // indirect


### PR DESCRIPTION
Upgrade to make it compatible with standard install method by `go install github.com/devploit/dontgo403@latest`