### PR TITLE
Support forcing a different HTTP method for all payloads except httpmethods

### DIFF
--- a/cmd/requester.go
+++ b/cmd/requester.go
@@ -69,7 +69,7 @@ func requestMethods(uri string, headers []header, proxy *url.URL, folder string)
 	printResponse(results)
 }
 
-func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp string, folder string) {
+func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp string, folder string, method string) {
 	color.Cyan("\n[####] VERB TAMPERING [####]")
 
 	var lines []string
@@ -104,7 +104,7 @@ func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp strin
 			go func(line, ip string) {
 				headers := append(headers, header{line, ip})
 
-				statusCode, response, err := request("GET", uri, headers, proxy)
+				statusCode, response, err := request(method, uri, headers, proxy)
 
 				if err != nil {
 					log.Println(err)
@@ -123,7 +123,7 @@ func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp strin
 			x := strings.Split(line, " ")
 			headers := append(headers, header{x[0], x[1]})
 
-			statusCode, response, err := request("GET", uri, headers, proxy)
+			statusCode, response, err := request(method, uri, headers, proxy)
 			if err != nil {
 				log.Println(err)
 			}
@@ -136,7 +136,7 @@ func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp strin
 	printResponse(results)
 }
 
-func requestEndPaths(uri string, headers []header, proxy *url.URL, folder string) {
+func requestEndPaths(uri string, headers []header, proxy *url.URL, folder string, method string) {
 	color.Cyan("\n[####] CUSTOM PATHS [####]")
 
 	var lines []string
@@ -153,7 +153,7 @@ func requestEndPaths(uri string, headers []header, proxy *url.URL, folder string
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 		w.Wait()
 		go func(line string) {
-			statusCode, response, err := request("GET", uri+line, headers, proxy)
+			statusCode, response, err := request(method, uri+line, headers, proxy)
 			if err != nil {
 				log.Println(err)
 			}
@@ -166,7 +166,7 @@ func requestEndPaths(uri string, headers []header, proxy *url.URL, folder string
 	printResponse(results)
 }
 
-func requestMidPaths(uri string, headers []header, proxy *url.URL, folder string) {
+func requestMidPaths(uri string, headers []header, proxy *url.URL, folder string, method string) {
 	var lines []string
 	lines, err := parseFile(folder + "/midpaths")
 	if err != nil {
@@ -200,7 +200,7 @@ func requestMidPaths(uri string, headers []header, proxy *url.URL, folder string
 				fullpath = baseuri + "/" + line + uripath
 			}
 
-			statusCode, response, err := request("GET", fullpath, headers, proxy)
+			statusCode, response, err := request(method, fullpath, headers, proxy)
 			if err != nil {
 				log.Println(err)
 			}
@@ -213,7 +213,7 @@ func requestMidPaths(uri string, headers []header, proxy *url.URL, folder string
 	printResponse(results)
 }
 
-func requestCapital(uri string, headers []header, proxy *url.URL) {
+func requestCapital(uri string, headers []header, proxy *url.URL, method string) {
 	color.Cyan("\n[####] CAPITALIZATION [####]")
 
 	x := strings.Split(uri, "/")
@@ -244,7 +244,7 @@ func requestCapital(uri string, headers []header, proxy *url.URL) {
 				fullpath = baseuri + "/" + newpath
 			}
 
-			statusCode, response, err := request("GET", fullpath, headers, proxy)
+			statusCode, response, err := request(method, fullpath, headers, proxy)
 			if err != nil {
 				log.Println(err)
 			}
@@ -257,7 +257,7 @@ func requestCapital(uri string, headers []header, proxy *url.URL) {
 	printResponse(results)
 }
 
-func requester(uri string, proxy string, userAgent string, req_headers []string, bypassIp string, folder string) {
+func requester(uri string, proxy string, userAgent string, req_headers []string, bypassIp string, folder string, method string) {
 	if len(proxy) != 0 {
 		if !strings.Contains(proxy, "http") {
 			proxy = "http://" + proxy
@@ -272,6 +272,9 @@ func requester(uri string, proxy string, userAgent string, req_headers []string,
 	if len(userAgent) == 0 {
 		userAgent = "dontgo403"
 	}
+	if len(method) == 0 {
+		method = "GET"
+	}
 
 	headers := []header{
 		{"User-Agent", userAgent},
@@ -285,8 +288,8 @@ func requester(uri string, proxy string, userAgent string, req_headers []string,
 	}
 
 	requestMethods(uri, headers, userProxy, folder)
-	requestHeaders(uri, headers, userProxy, bypassIp, folder)
-	requestEndPaths(uri, headers, userProxy, folder)
-	requestMidPaths(uri, headers, userProxy, folder)
-	requestCapital(uri, headers, userProxy)
+	requestHeaders(uri, headers, userProxy, bypassIp, folder, method)
+	requestEndPaths(uri, headers, userProxy, folder, method)
+	requestMidPaths(uri, headers, userProxy, folder, method)
+	requestCapital(uri, headers, userProxy, method)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var (
 	req_headers    []string
 	bypassIp       string
 	folder         string
-	httpMethod     string
+	httpVerb       string
 )
 
 // rootCmd
@@ -45,14 +45,14 @@ var rootCmd = &cobra.Command{
 				if uri == lastchar {
 					break
 				}
-				requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
+				requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpVerb)
 			}
 		} else {
 			if len(uri) == 0 {
 				cmd.Help()
 				log.Fatal()
 			}
-			requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
+			requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpVerb)
 		}
 	},
 }
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&req_headers, "header", "H", []string{""}, "Add a custom header to the requests (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&bypassIp, "bypassIp", "b", "", "Try bypass tests with a specific IP address (or hostname). i.e.: 'X-Forwarded-For: 192.168.0.1' instead of 'X-Forwarded-For: 127.0.0.1'")
 	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "Define payloads folder (if it's not in the same path as binary)")
-	rootCmd.PersistentFlags().StringVarP(&httpMethod, "httpMethod", "hp", "", "HTTP method to use (default 'GET')")
+	rootCmd.PersistentFlags().StringVarP(&httpVerb, "verb", "v", "", "HTTP method to use (default 'GET')")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	req_headers    []string
 	bypassIp       string
 	folder         string
+	method         string
 )
 
 // rootCmd
@@ -44,14 +45,14 @@ var rootCmd = &cobra.Command{
 				if uri == lastchar {
 					break
 				}
-				requester(uri, proxy, useragent, req_headers, bypassIp, folder)
+				requester(uri, proxy, useragent, req_headers, bypassIp, folder, method)
 			}
 		} else {
 			if len(uri) == 0 {
 				cmd.Help()
 				log.Fatal()
 			}
-			requester(uri, proxy, useragent, req_headers, bypassIp, folder)
+			requester(uri, proxy, useragent, req_headers, bypassIp, folder, method)
 		}
 	},
 }
@@ -73,6 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&req_headers, "header", "H", []string{""}, "Add a custom header to the requests (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&bypassIp, "bypassIp", "b", "", "Try bypass tests with a specific IP address (or hostname). i.e.: 'X-Forwarded-For: 192.168.0.1' instead of 'X-Forwarded-For: 127.0.0.1'")
 	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "Define payloads folder (if it's not in the same path as binary)")
+	rootCmd.PersistentFlags().StringVarP(&method, "method", "m", "", "HTTP method to use (default 'GET')")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&req_headers, "header", "H", []string{""}, "Add a custom header to the requests (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&bypassIp, "bypassIp", "b", "", "Try bypass tests with a specific IP address (or hostname). i.e.: 'X-Forwarded-For: 192.168.0.1' instead of 'X-Forwarded-For: 127.0.0.1'")
 	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "Define payloads folder (if it's not in the same path as binary)")
-	rootCmd.PersistentFlags().StringVarP(&method, "method", "m", "", "HTTP method to use (default 'GET')")
+	rootCmd.PersistentFlags().StringVarP(&method, "httpMethod", "hp", "", "HTTP method to use (default 'GET')")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var (
 	req_headers    []string
 	bypassIp       string
 	folder         string
-	httpVerb       string
+	httpMethod     string
 )
 
 // rootCmd
@@ -45,14 +45,14 @@ var rootCmd = &cobra.Command{
 				if uri == lastchar {
 					break
 				}
-				requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpVerb)
+				requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
 			}
 		} else {
 			if len(uri) == 0 {
 				cmd.Help()
 				log.Fatal()
 			}
-			requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpVerb)
+			requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
 		}
 	},
 }
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&req_headers, "header", "H", []string{""}, "Add a custom header to the requests (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&bypassIp, "bypassIp", "b", "", "Try bypass tests with a specific IP address (or hostname). i.e.: 'X-Forwarded-For: 192.168.0.1' instead of 'X-Forwarded-For: 127.0.0.1'")
 	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "Define payloads folder (if it's not in the same path as binary)")
-	rootCmd.PersistentFlags().StringVarP(&httpVerb, "verb", "v", "", "HTTP method to use (default 'GET')")
+	rootCmd.PersistentFlags().StringVarP(&httpMethod, "httpMethod", "t", "", "HTTP method to use (default 'GET')")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var (
 	req_headers    []string
 	bypassIp       string
 	folder         string
-	method         string
+	httpMethod     string
 )
 
 // rootCmd
@@ -45,14 +45,14 @@ var rootCmd = &cobra.Command{
 				if uri == lastchar {
 					break
 				}
-				requester(uri, proxy, useragent, req_headers, bypassIp, folder, method)
+				requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
 			}
 		} else {
 			if len(uri) == 0 {
 				cmd.Help()
 				log.Fatal()
 			}
-			requester(uri, proxy, useragent, req_headers, bypassIp, folder, method)
+			requester(uri, proxy, useragent, req_headers, bypassIp, folder, httpMethod)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&req_headers, "header", "H", []string{""}, "Add a custom header to the requests (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&bypassIp, "bypassIp", "b", "", "Try bypass tests with a specific IP address (or hostname). i.e.: 'X-Forwarded-For: 192.168.0.1' instead of 'X-Forwarded-For: 127.0.0.1'")
 	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "Define payloads folder (if it's not in the same path as binary)")
-	rootCmd.PersistentFlags().StringVarP(&method, "httpMethod", "hp", "", "HTTP method to use (default 'GET')")
+	rootCmd.PersistentFlags().StringVarP(&httpMethod, "httpMethod", "hp", "", "HTTP method to use (default 'GET')")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Hi, thanks for publishing this tool!
This is a small change to support HTTP endpoints that should be queried with another HTTP method.