### PR TITLE
requester.go: Corrected wording

### DIFF
--- a/cmd/requester.go
+++ b/cmd/requester.go
@@ -40,7 +40,7 @@ func printResponse(results []Result) {
 }
 
 func requestMethods(uri string, headers []header, proxy *url.URL, folder string) {
-	color.Cyan("\n[####] HTTP METHODS [####]")
+	color.Cyan("\n[####] VERB TAMPERING [####]")
 
 	var lines []string
 	lines, err := parseFile(folder + "/httpmethods")
@@ -70,7 +70,7 @@ func requestMethods(uri string, headers []header, proxy *url.URL, folder string)
 }
 
 func requestHeaders(uri string, headers []header, proxy *url.URL, bypassIp string, folder string, method string) {
-	color.Cyan("\n[####] VERB TAMPERING [####]")
+	color.Cyan("\n[####] HEADERS [####]")
 
 	var lines []string
 	lines, err := parseFile(folder + "/headers")


### PR DESCRIPTION
- Replaced "HTTP METHODS" with "VERB TAMPERING"
- Replaced "VERB TAMPERING" with "HEADERS"

According to every source I could find, verb tampering is used to refer to an attack that focuses on tinkering with the HTTP Method. The part of the code that had that title, actually attempted header-based bypasses, so this pr should fix that.