### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dontgo403
+module devploit/dontgo403
 
 go 1.19
 


### PR DESCRIPTION
update go.mod to make the script installable using "go install" command
the command should be `go install github.com/devploit/dontgo403@latest'
and it will be easier to install and easier to execute, because that the binary will be in $GOPATH